### PR TITLE
fix webpack environment args

### DIFF
--- a/args.js
+++ b/args.js
@@ -1,0 +1,25 @@
+const path = require('path');
+
+function getArgs() {
+  require('dotenv').config({
+    path: path.join(__dirname, '.env'),
+  });
+
+  const requiredArgs = ['SENDGRID_TOKEN', 'GITHUB_TOKEN', 'GITHUB_USER'];
+  if (requiredArgs.some(arg => !process.env[arg])) {
+    console.error(`Not all required environment variables have been specified.
+  Please inspect \`.env.example\`. Required are:
+  ${JSON.stringify(requiredArgs, null, 2)}`);
+    process.exit(1);
+  }
+
+  return requiredArgs.reduce(
+    (acc, curr) => ({
+      ...acc,
+      [`process.env.${curr}`]: JSON.stringify(process.env[curr]),
+    }),
+    {}
+  );
+}
+
+module.exports = { getArgs };

--- a/nextron.config.js
+++ b/nextron.config.js
@@ -1,0 +1,9 @@
+const webpack = require('webpack'); // shipped with NextJS
+const { getArgs } = require('./args');
+
+module.exports = {
+  webpack: config => {
+    config.plugins.push(new webpack.DefinePlugin(getArgs()));
+    return config;
+  },
+};

--- a/renderer/next.config.js
+++ b/renderer/next.config.js
@@ -1,19 +1,7 @@
-const path = require('path');
+const webpack = require('webpack'); // shipped with NextJS
 const withCSS = require('@zeit/next-css');
 const withImages = require('next-images');
-const webpack = require('webpack'); // shipped with NextJS
-
-require('dotenv').config({
-  path: path.join(__dirname, '..', '.env'),
-});
-
-const requiredArgs = ['SENDGRID_TOKEN', 'GITHUB_TOKEN', 'GITHUB_USER'];
-if (requiredArgs.some(arg => !process.env[arg])) {
-  console.error(`Not all required environment variables have been specified.
-Please inspect \`.env.example\`. Required are:
-${JSON.stringify(requiredArgs, null, 2)}`);
-  process.exit(1);
-}
+const { getArgs } = require('../args');
 
 module.exports = withCSS(
   withImages({
@@ -24,15 +12,7 @@ module.exports = withCSS(
 
     webpack: config => {
       config.target = 'electron-renderer';
-
-      const env = requiredArgs.reduce(
-        (acc, curr) => ({
-          ...acc,
-          [`process.env.${curr}`]: JSON.stringify(process.env[curr]),
-        }),
-        {}
-      );
-      config.plugins.push(new webpack.DefinePlugin(env));
+      config.plugins.push(new webpack.DefinePlugin(getArgs()));
 
       return config;
     },


### PR DESCRIPTION
nextron has a [`nextron.config.js`](https://github.com/saltyshiomix/nextron#nextronconfigjs) for specifying environment variables for the main/background thread webpack build (the renderer thread is built separately via NextJS). this PR adds our environment variables now to this webpack configuration.

fixes #53.