### PR TITLE
Fix bug in the INK clone popup modal 

### DIFF
--- a/main/background.js
+++ b/main/background.js
@@ -108,7 +108,7 @@ app.on('open-url', function (event, requestUrl) {
     return;
   }
 
-  const openImportProject = (rendererWindow) => {
+  openImportProject = (rendererWindow) => {
     ipc.callRenderer(rendererWindow, 'to-renderer', {
       event: 'import-project-from-external',
       data: {


### PR DESCRIPTION
@jan the popup doesn’t work because you added a const in line `main/background.js#111` in your force commit 0b1934b6 which changed the scope of variable `openImportProject` from global to local